### PR TITLE
feat:bugfix

### DIFF
--- a/GodSaeng/src/main/java/com/planner/godsaeng/controller/ChallengeController.java
+++ b/GodSaeng/src/main/java/com/planner/godsaeng/controller/ChallengeController.java
@@ -154,7 +154,8 @@ public class ChallengeController {
 		}
 	}
 	@PostMapping("/verify")
-	public ResponseEntity<Boolean>VerifyNormalChallenge(@RequestBody ChallengeVerifyDTO v, MultipartFile verifyPhoto)throws IOException{
+	public ResponseEntity<Boolean>VerifyNormalChallenge(@ModelAttribute ChallengeVerifyDTO v, @AuthenticationPrincipal JwtAuthentication user, @RequestParam("verifyPhoto") MultipartFile verifyPhoto)throws IOException{
+		System.out.println(v.getCid());
 		boolean isVerifySuccessed = verifyservice.InsertNormalChallengeVerifyData(v, verifyPhoto);
 		if(isVerifySuccessed) {
 			return ResponseEntity.ok(true);

--- a/GodSaeng/src/main/java/com/planner/godsaeng/repository/ChallengeRepository.java
+++ b/GodSaeng/src/main/java/com/planner/godsaeng/repository/ChallengeRepository.java
@@ -70,7 +70,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge,Long > {
 //	        "GROUP BY godsaeng_challengeparticipate.cpid", nativeQuery = true)
 //	List<Object[]> myChallengeProgress(@Param("uid") String uid);
 //	
-	@Query(value = "SELECT godsaeng_challenge.cid, cname, cthumbnails, cstartdate, cenddate, ctypeofverify " +
+	@Query(value = "SELECT godsaeng_challenge.cid, cname, cthumbnails, cstartdate, cenddate, ctypeofverify, " +
 	        "cenddate - cstartdate + 1 AS datediff, " +
 	        "CASE " +
 	        "    WHEN ctypeoffrequency = 2 THEN CEILING((cenddate - cstartdate + 1) / cfrequency) " +

--- a/GodSaeng/src/main/java/com/planner/godsaeng/service/ChallengeDataConverter.java
+++ b/GodSaeng/src/main/java/com/planner/godsaeng/service/ChallengeDataConverter.java
@@ -19,7 +19,7 @@ public class ChallengeDataConverter implements Converter<Object[], ChallengeStat
         convertedChallengeStatusDTO.setCthumbnails((String) source[2]);
         convertedChallengeStatusDTO.setCstartdate((Date) source[3]);
         convertedChallengeStatusDTO.setCenddate((Date) source[4]);
-        convertedChallengeStatusDTO.setCtypeofverify((Integer) source[4]);
+        convertedChallengeStatusDTO.setCtypeofverify((Integer) source[5]);
         convertedChallengeStatusDTO.setDatediff((BigInteger) source[6]);
         convertedChallengeStatusDTO.setTotalcount((BigInteger) source[7]);
         convertedChallengeStatusDTO.setCvsuccesscount(((BigInteger) source[9]));


### PR DESCRIPTION
일반챌린지 인증 수정
마이챌린지 데이터 요청시 메타버스인지 , 일반챌린지인지 구분할 수 있는 구분자 데이터까지 return